### PR TITLE
use extra_metadata

### DIFF
--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -109,7 +109,7 @@ def open_mdsdataset(data_dir, grid_dir=None,
         configuration.
     extra_metadata : dict, optional
         Allow to pass information on llc type grid (global or regional),
-        or notify that we want to read in 2D slice of a 3D variable
+        or notify that we want to read in 2D diagnostic of a 3D variable
         (e.g. one level, vertical integral).
 
         The additional metadata is typically such as :


### PR DESCRIPTION
I basically hijacked extra_metadata to add a flag for doing what we want. I ran `py.test xmitgcm` on my machine and only got one memmap error (too many open files, seems to happen somewhat randomly), so hopefully this is OK. 

Still need to add the specific tests @rabernat mentioned. 

There is still the following caveat: if there are a bunch of files with the same variables, 1 file with 3D variables and 1 with 2D diagnostics of the same variables, it only takes what it reads last. I think this is pretty much impossible to avoid at the moment though, unless we change the 2D slice variable name.

Lastly let me know if I should've contributed to the PR a different way, I was following [this guide](https://github.com/TeamPorcupine/ProjectPorcupine/wiki/How-to-Test-a-Pull-Request)